### PR TITLE
Better sampler for slow networks

### DIFF
--- a/cfspeed/io-sampler.go
+++ b/cfspeed/io-sampler.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const nIOEventsMin = 4
+
 type IOEvent struct {
 	Timestamp time.Time
 	Mode      string
@@ -36,12 +38,17 @@ func InitReadSampler(size int64) *ReadSampler {
 
 func (r *ReadSampler) Read(p []byte) (int, error) {
 	var err error = nil
+
 	size := len(p)
 	size64 := int64(size)
+	if size64 > r.cEOF/nIOEventsMin {
+		size64 = r.cEOF / nIOEventsMin
+		size = int(size64)
+	}
 
 	r.ctr += size64
 
-	if r.ctr > r.cEOF {
+	if r.ctr >= r.cEOF {
 		size = int(size64 - (r.ctr - r.cEOF))
 		err = io.EOF
 		r.ctr = r.cEOF

--- a/cfspeed/root.go
+++ b/cfspeed/root.go
@@ -75,14 +75,14 @@ func RunAndPrint(transportProtocol string) {
 	printMetadata(measurementMetadata, err)
 	fmt.Println()
 
-	measurementRTT, err := MeasureRTT()
-	printRTTMeasurement(measurementRTT, err)
+	rttStats, cfReqDurStats, err := MeasureRTT()
+	printRTTMeasurement(rttStats, err)
 	fmt.Println()
 
-	measurementDown, err := MeasureSpeedAdaptive(MeasureDownlink)
-	printAdaptiveSpeedMeasurement("Downlink", measurementDown, err)
+	downlinkStats, err := MeasureSpeedAdaptive("down", rttStats, cfReqDurStats)
+	printAdaptiveSpeedMeasurement("Downlink", downlinkStats, err)
 	fmt.Println()
 
-	measurementUp, err := MeasureSpeedAdaptive(MeasureUplink)
-	printAdaptiveSpeedMeasurement("Uplink", measurementUp, err)
+	uplinkStats, err := MeasureSpeedAdaptive("up", rttStats, cfReqDurStats)
+	printAdaptiveSpeedMeasurement("Uplink", uplinkStats, err)
 }

--- a/cfspeed/root.go
+++ b/cfspeed/root.go
@@ -3,7 +3,6 @@ package cfspeed
 import (
 	"context"
 	"fmt"
-	"math"
 	"net"
 	"net/http"
 	"os"
@@ -44,7 +43,7 @@ func printAdaptiveSpeedMeasurement(label string, measurement *SpeedMeasurementSt
 		fmt.Printf("%s-min: %.3f Mbps\n", label, measurement.Min)
 		fmt.Printf("%s-max: %.3f Mbps\n", label, measurement.Max)
 		fmt.Printf("%s-cat: %.3f Mbps\n", label, measurement.CatSpeed)
-		fmt.Printf("%s-tx: %.3f MiB\n", label, math.Round(float64(measurement.TXSize)/1024/1024))
+		fmt.Printf("%s-tx: %.3f MiB\n", label, float64(measurement.TXSize)/1024/1024)
 		fmt.Printf("%s-ntx: %d\n", label, measurement.NTX)
 		fmt.Printf("%s-n: %d\n", label, measurement.NSamples)
 	}

--- a/cfspeed/types.go
+++ b/cfspeed/types.go
@@ -16,6 +16,7 @@ type MeasurementMetadata struct {
 type Stats struct {
 	NSamples int
 	Mean     float64
+	StdDev   float64
 	StdErr   float64
 	Min      float64
 	MinIndex int
@@ -25,6 +26,8 @@ type Stats struct {
 
 type SpeedMeasurement struct {
 	Size           int64
+	Start          time.Time
+	End            time.Time
 	Duration       time.Duration
 	IOSampler      IOSampler
 	HTTPRespHeader http.Header


### PR DESCRIPTION
* Adjust chunk size based on reader size
* Do not round transmitted data size
* Use start time, end time, RTT and cfRequestDuration as hints